### PR TITLE
Switch from elftools to lief

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ This tool detects and repairs the following common modifications:
 
 The script requires the following libraries listed on `requirements.txt`:
 
-- [`elftools`](https://github.com/eliben/pyelftools)
+- [`lief`](https://lief-project.github.io)
 - [`python-magic`](https://pypi.org/project/python-magic/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyelftools==0.28
+lief==0.12.1
 python-magic==0.4.27


### PR DESCRIPTION
`lief` library can properly handle errors induced from ELF files with tricky headers and the changes to the code are minimal. Some parts of the code (entry point bytes obtaining process) are even more straightforward.